### PR TITLE
Don't support 3.6 anymore.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-18.04, macos-latest, windows-latest]
         flask-version: [1.0, 1.1, 2.0, latest]
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jack Grahl <jack.grahl@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 Flask = "^1.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This version of Python is now end of life.

We might remove support for it, if and when it starts to cause us problems.

So far we saw one problem - detection of the line numbers where functions are declared has changed.