### PR TITLE
Add Flask 2.x compatibility + fix line number detection under python <= 3.8 and python 3.11

### DIFF
--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -7,22 +7,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        os: [ubuntu-18.04]
+        python-version: ['3.8', '3.9', '3.10']
         flask-version: [latest]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install poetry
-        run: pip install poetry
-      - name: Force the chosen flask version
-        run: poetry add flask==${{ matrix.flask-version }}
+        run: pip3 install poetry
+
+      - name: Force Python version (linux/macOS)
+        if: matrix.os != 'windows-latest'
+        # sed command for macOS: https://stackoverflow.com/a/44864004
+        run: sed -i.bak 's/python = "^3.6"/python = "~${{ matrix.python-version }}"/' pyproject.toml
+
+      - name: Force Python version (windows)
+        if: matrix.os == 'windows-latest'
+        run: (Get-Content pyproject.toml).replace('python = "^3.6"', 'python = "~${{ matrix.python-version }}"') | Set-Content pyproject.toml
+
+      - name: Force Flask version
+        run: poetry add Flask==${{ matrix.flask-version }}
+
       - name: Install requirements
         run: poetry install
+
+      - name: List installed package versions for manual inspection
+        run: poetry --version && poetry show
+
       - name: Test package
         run: poetry run test
+
       - name: Test package
         run: poetry run doctest

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,22 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'nodeploy')"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
+
       - name: Install poetry
         run: pip install poetry
+
       - name: Install requirements
         run: poetry install
+
       - name: Build package
         run: poetry build
+
       - name: Test package
         run: poetry run pytest
+
       - name: Check if already uploaded
         id: check_pypi
         run: poetry run check_pypi_prerelease
         continue-on-error: true
+
       - name: publish to pypi
         run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
         if: steps.check_pypi.outcome == 'success'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Deploy release version to pypi
 on:
   push:
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -11,19 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'nodeploy')"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
+
       - name: Install poetry
         run: pip install poetry
+
       - name: Install requirements
         run: poetry install
+
       - name: Build package
         run: poetry build
+
       - name: Test package
         run: poetry run pytest
+
       - name: Check if already uploaded
         run: poetry run check_pypi
+
       - name: publish to pypi
         run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,26 +3,174 @@ on:
    - pull_request
 
 jobs:
+
   testing:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
-        flask-version: ["1.0", 1.1, "2.0", latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.x']
+        flask-version: ['1.0', '1.1', '2.0', '2.1', 'latest']
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        exclude:
+          # starting from Flask 2.1.0, python 3.6 is no longer supported:
+          - flask-version: '2.1'
+            python-version: '3.6'
+
+          - flask-version: 'latest'
+            python-version: '3.6'
+
+          # old versions of Flask no longer working with python >= 3.10:
+          - flask-version: '1.0'
+            python-version: '3.10'
+
+          - flask-version: '1.0'
+            python-version: '3.x'
+
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
-        run: pip install poetry
-      - name: Force the chosen flask version
-        run: poetry add flask==${{ matrix.flask-version }}
-      - name: Install requirements
-        run: poetry install
+
+      - name: Install dev dependencies (python 3.6)
+        if: matrix.python-version == '3.6'
+        run: |
+          pip3 install poetry
+          poetry export --dev --without-hashes --format requirements.txt --output requirements-dev.txt
+          pip3 install -r requirements-dev.txt
+
+      - name: Install Flask ${{ matrix.flask-version }}
+        if: matrix.flask-version != 'latest'
+        run: pip3 install Flask==${{ matrix.flask-version }}
+
+      - name: Install latest Flask
+        if: matrix.flask-version == 'latest'
+        run: pip3 install Flask
+
+      - name: Install dev dependencies (python >= 3.7)
+        if: matrix.python-version != '3.6'
+        run: |
+          pip3 install poetry
+          poetry export --only dev --format requirements.txt --output requirements-dev.txt
+          pip3 install -r requirements-dev.txt
+
+      - name: Overwrite Flask dependencies for legacy install
+        if: matrix.flask-version < '2.0' && matrix.flask-version != 'latest'
+        run: |
+          pip3 install "Jinja2<3.0"
+          pip3 install "MarkupSafe<=2.0.1"
+          pip3 install "itsdangerous<=2.0.1"
+
+      - name: Overwrite Flask dependencies for legacy install (2)
+        if: matrix.flask-version < '2.1' && matrix.flask-version != 'latest'
+        run: pip3 install "werkzeug<=2.0.3"
+
+      - name: List installed package versions for manual inspection
+        run: python3 --version && pip3 list
+
       - name: Run unit tests
-        run: poetry run test
+        run: python3 -c "from run_tests import test; test()"
+
       - name: Run doctests
-        run: poetry run doctest
+        run: python3 -c "from run_tests import run_doctest; run_doctest()"
+
+  check_pip_install:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.x']
+        flask-version: ['1.0', '1.1', '2.0', '2.1', 'latest']
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        exclude:
+          # starting from Flask 2.1.0, python 3.6 is no longer supported:
+          - flask-version: '2.1'
+            python-version: '3.6'
+
+          - flask-version: 'latest'
+            python-version: '3.6'
+
+          # old versions of Flask no longer working with python >= 3.10:
+          - flask-version: '1.0'
+            python-version: '3.10'
+
+          - flask-version: '1.0'
+            python-version: '3.x'
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dev dependencies (python 3.6)
+        # actually installs all dependencies (no --only flag in this version)
+        # so we run this without installing the target Flask version
+        if: matrix.python-version == '3.6'
+        run: |
+          pip3 install poetry
+          poetry export --dev --without-hashes --format requirements.txt --output requirements-dev.txt
+          pip3 install -r requirements-dev.txt
+
+      - name: Install Flask ${{ matrix.flask-version }}
+        if: matrix.flask-version != 'latest'
+        run: pip3 install Flask==${{ matrix.flask-version }}
+
+      - name: Install latest Flask
+        if: matrix.flask-version == 'latest'
+        run: pip3 install Flask
+
+      - name: Install current flask-selfdoc from GitHub (linux/macOS)
+        if: matrix.os != 'windows-latest'
+        run: |
+          git_url="${{ github.event.pull_request.head.repo.git_url }}@${{ github.event.pull_request.head.ref }}"
+          git_url="git+https${git_url:3}"
+          pip3 install ${git_url}
+
+      - name: Install current flask-selfdoc from GitHub (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          $git_url = "${{ github.event.pull_request.head.repo.git_url }}@${{ github.event.pull_request.head.ref }}"
+          $git_url = $git_url.subString(3)
+          $git_url = "git+https$git_url"
+          pip3 install $git_url
+
+      - name: Install dev dependencies (python >= 3.7)
+        if: matrix.python-version != '3.6'
+        run: |
+          pip3 install poetry
+          poetry export --only dev --format requirements.txt --output requirements-dev.txt
+          pip3 install -r requirements-dev.txt
+
+      - name: Overwrite Flask dependencies for legacy install
+        if: matrix.flask-version < '2.0' && matrix.flask-version != 'latest'
+        run: |
+          pip3 install "Jinja2<3.0"
+          pip3 install "MarkupSafe<=2.0.1"
+          pip3 install "itsdangerous<=2.0.1"
+
+      - name: Overwrite Flask dependencies for legacy install (2)
+        if: matrix.flask-version < '2.1' && matrix.flask-version != 'latest'
+        run: pip3 install "werkzeug<=2.0.3"
+
+      - name: List installed package versions for manual inspection
+        run: python3 --version && pip3 list
+
+      - name: Check that Flask version did not change
+        # not implemented for windows yet
+        if: matrix.flask-version != 'latest' && matrix.os != 'windows-latest'
+        run: |
+          flask_version=$(pip3 show Flask | grep Version:)
+          echo "found Flask ${flask_version}"
+          if [[ $(pip3 show Flask | grep Version) == *"Version: ${{ matrix.flask-version }}"* ]]
+          then
+            echo "No reinstall of Flask was done 👍"
+          else
+            exit 1
+          fi
+
+      - name: Try importing flask_selfdoc
+        run: python3 -c "import flask_selfdoc"

--- a/examples/custom/blog.py
+++ b/examples/custom/blog.py
@@ -1,7 +1,7 @@
-from os import path
 from json import dumps
 
-from flask import Flask, redirect, request, jsonify
+from flask import Flask, redirect, request
+from flask_selfdoc.autodoc import custom_jsonify
 from flask_selfdoc import Autodoc
 
 
@@ -58,7 +58,7 @@ def get_post(id):
 
 @app.route('/post', methods=["POST"])
 @auto.doc(groups=['posts', 'private'],
-    form_data=['title', 'content', 'authorid'])
+          form_data=['title', 'content', 'authorid'])
 def post_post():
     """Create a new post."""
     authorid = request.form.get('authorid', None)
@@ -84,7 +84,7 @@ def get_user(id):
 
 @app.route('/users', methods=['POST'])
 @auto.doc(groups=['users', 'private'],
-    form_data=['username'])
+          form_data=['username'])
 def post_user(id):
     """Creates a new user."""
     User(request.form['username'])
@@ -111,7 +111,7 @@ def private_doc():
 
 @app.route('/doc/json')
 def public_doc_json():
-    return jsonify(auto.generate())
+    return custom_jsonify(auto.generate(), indent=4, separators=(',', ': '))
 
 
 if __name__ == '__main__':

--- a/examples/simple/blog.py
+++ b/examples/simple/blog.py
@@ -1,6 +1,7 @@
 from json import dumps
 
-from flask import Flask, redirect, request, jsonify
+from flask import Flask, redirect, request
+from flask_selfdoc.autodoc import custom_jsonify
 from flask_selfdoc import Autodoc
 
 
@@ -128,12 +129,12 @@ def private_doc():
 
 @app.route('/doc/json')
 def public_doc_json():
-    return jsonify(auto.generate())
+    return custom_jsonify(auto.generate(), indent=4, separators=(',', ': '))
 
 
 @app.route('/doc/builtin_json')
 def public_doc_builtin_json():
-    return auto.json()
+    return auto.json(indent=2, separators=(',', ': '))
 
 
 if __name__ == '__main__':

--- a/flask_selfdoc/autodoc.py
+++ b/flask_selfdoc/autodoc.py
@@ -25,9 +25,13 @@ except ImportError:
     Markup = markupsafe.Markup
 
 try:
-    from flask import _app_ctx_stack as stack
+    from flask.globals import _cv_app
 except ImportError:
-    from flask import _request_ctx_stack as stack
+    _cv_app = None
+    try:
+        from flask import _app_ctx_stack as stack
+    except ImportError:
+        from flask import _request_ctx_stack as stack
 
 
 if sys.version < '3':
@@ -58,7 +62,10 @@ class Autodoc(object):
         self.add_custom_template_filters(app)
 
     def teardown(self, exception):
-        ctx = stack.top  # noqa: F841
+        if _cv_app is not None:
+            ctx = _cv_app.get(None)  # noqa: F841
+        else:
+            ctx = stack.top  # noqa: F841
 
     def add_custom_template_filters(self, app):
         """Add custom filters to jinja2 templating engine"""

--- a/flask_selfdoc/autodoc.py
+++ b/flask_selfdoc/autodoc.py
@@ -6,9 +6,23 @@ import sys
 import inspect
 
 from flask import current_app, render_template, render_template_string, jsonify
-from jinja2 import evalcontextfilter, Markup
 from jinja2.exceptions import TemplateAssertionError
 
+try:
+    # Jinja2 < 3.1 (Flask <= 2.0 and python 3.6)
+    # https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.evalcontextfilter
+    from jinja2 import evalcontextfilter as pass_eval_context
+except ImportError:
+    # Jinja2 < 3.1 (Flask >= 2.0 and python <= 3.7)
+    from jinja2 import pass_eval_context
+
+try:
+    # Jinja2 < 3.1 (Flask <= 2.0 and python 3.6)
+    from jinja2 import Markup
+except ImportError:
+    # Jinja2 < 3.1 (Flask >= 2.0 and python <= 3.7)
+    from jinja2.utils import markupsafe
+    Markup = markupsafe.Markup
 
 try:
     from flask import _app_ctx_stack as stack
@@ -57,7 +71,7 @@ class Autodoc(object):
         _paragraph_re = re.compile(r'(?:\r\n|\r|\n){3,}')
 
         @app.template_filter()
-        @evalcontextfilter
+        @pass_eval_context
         def nl2br(eval_ctx, value):
             result = '\n\n'.join('%s' % p.replace('\n', Markup('<br>\n'))
                                  for p in _paragraph_re.split(value))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Flask = "^1.0"
+Flask = [
+    {python = "~3.6", version = ">=1.0, <2.1"},
+    {python = ">=3.7, <3.10", version = ">=1.0"},
+    {python = "~3.10", version = ">=1.1"}
+]
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,5 @@
 import doctest
 import logging
-import os
 import subprocess
 import unittest
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,10 +1,3 @@
 import os
-import sys
-
-# The way that the line number of a function is detected changed
-# The old version chooses the location of the first decorator,
-# the new version chooses the location of the 'def' keyword.
-# We detect the version and support both.
-NEW_FN_OFFSETS = sys.version_info >= (3, 8)
 
 IS_WINDOWS = os.name == 'nt'

--- a/tests/files/builtin.json
+++ b/tests/files/builtin.json
@@ -1,1 +1,126 @@
-{"endpoints":[{"args":[],"docstring":"Return all posts.","methods":["GET","HEAD","OPTIONS"],"rule":"/"},{"args":[],"docstring":"Admin interface.","methods":["GET","HEAD","OPTIONS"],"rule":"/admin"},{"args":[["greeting","Hello"],["id",null]],"docstring":"Return the user for the given id.","methods":["GET","HEAD","OPTIONS"],"rule":"/greet/<greeting>/user/<int:id>"},{"args":[["id",-1]],"docstring":"Return the user for the given id.","methods":["GET","HEAD","OPTIONS"],"rule":"/hello/user/<int:id>"},{"args":[],"docstring":"Create a new post.\n    Form Data: title, content, authorid.\n    ","methods":["OPTIONS","POST"],"rule":"/post"},{"args":[["id",null]],"docstring":"Return the post for the given id.","methods":["GET","HEAD","OPTIONS"],"rule":"/post/<int:id>"},{"args":[],"docstring":"Return all posts.","methods":["GET","HEAD","OPTIONS"],"rule":"/posts"},{"args":[["id",null]],"docstring":"Return the user for the given id.","methods":["GET","HEAD","OPTIONS"],"rule":"/user/<int:id>"},{"args":[],"docstring":"Return all users.","methods":["GET","HEAD","OPTIONS"],"rule":"/users"},{"args":[],"docstring":"Creates a new user.\n    Form Data: username.\n    ","methods":["OPTIONS","POST"],"rule":"/users"}]}
+{
+  "endpoints": [
+    {
+      "args": [],
+      "docstring": "Return all posts.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/"
+    },
+    {
+      "args": [],
+      "docstring": "Admin interface.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/admin"
+    },
+    {
+      "args": [
+        [
+          "greeting",
+          "Hello"
+        ],
+        [
+          "id",
+          null
+        ]
+      ],
+      "docstring": "Return the user for the given id.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/greet/<greeting>/user/<int:id>"
+    },
+    {
+      "args": [
+        [
+          "id",
+          -1
+        ]
+      ],
+      "docstring": "Return the user for the given id.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/hello/user/<int:id>"
+    },
+    {
+      "args": [],
+      "docstring": "Create a new post.\n    Form Data: title, content, authorid.\n",
+      "methods": [
+        "OPTIONS",
+        "POST"
+      ],
+      "rule": "/post"
+    },
+    {
+      "args": [
+        [
+          "id",
+          null
+        ]
+      ],
+      "docstring": "Return the post for the given id.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/post/<int:id>"
+    },
+    {
+      "args": [],
+      "docstring": "Return all posts.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/posts"
+    },
+    {
+      "args": [
+        [
+          "id",
+          null
+        ]
+      ],
+      "docstring": "Return the user for the given id.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/user/<int:id>"
+    },
+    {
+      "args": [],
+      "docstring": "Return all users.",
+      "methods": [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ],
+      "rule": "/users"
+    },
+    {
+      "args": [],
+      "docstring": "Creates a new user.\n    Form Data: username.\n",
+      "methods": [
+        "OPTIONS",
+        "POST"
+      ],
+      "rule": "/users"
+    }
+  ]
+}

--- a/tests/files/custom.json
+++ b/tests/files/custom.json
@@ -1,152 +1,152 @@
 [
-  {
-    "args": [
-      "None"
-    ], 
-    "defaults": {}, 
-    "docstring": "Return all posts.", 
-    "endpoint": "get_posts", 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 47
-    }, 
-    "methods": [
-      "GET", 
-      "HEAD", 
-      "OPTIONS"
-    ], 
-    "rule": "/"
-  }, 
-  {
-    "args": [
-      "None"
-    ], 
-    "defaults": {}, 
-    "docstring": "Admin interface.", 
-    "endpoint": "admin", 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 96
-    }, 
-    "methods": [
-      "GET", 
-      "HEAD", 
-      "OPTIONS"
-    ], 
-    "rule": "/admin"
-  }, 
-  {
-    "args": [
-      "None"
-    ], 
-    "defaults": {}, 
-    "docstring": "Create a new post.", 
-    "endpoint": "post_post", 
-    "form_data": [
-      "title", 
-      "content", 
-      "authorid"
-    ], 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 62
-    }, 
-    "methods": [
-      "OPTIONS", 
-      "POST"
-    ], 
-    "rule": "/post"
-  }, 
-  {
-    "args": [
-      "id"
-    ], 
-    "defaults": {}, 
-    "docstring": "Return the post for the given id.", 
-    "endpoint": "get_post", 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 54
-    }, 
-    "methods": [
-      "GET", 
-      "HEAD", 
-      "OPTIONS"
-    ], 
-    "rule": "/post/<int:id>"
-  }, 
-  {
-    "args": [
-      "None"
-    ], 
-    "defaults": {}, 
-    "docstring": "Return all posts.", 
-    "endpoint": "get_posts", 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 47
-    }, 
-    "methods": [
-      "GET", 
-      "HEAD", 
-      "OPTIONS"
-    ], 
-    "rule": "/posts"
-  }, 
-  {
-    "args": [
-      "id"
-    ], 
-    "defaults": {}, 
-    "docstring": "Return the user for the given id.", 
-    "endpoint": "get_user", 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 80
-    }, 
-    "methods": [
-      "GET", 
-      "HEAD", 
-      "OPTIONS"
-    ], 
-    "rule": "/user/<int:id>"
-  }, 
-  {
-    "args": [
-      "None"
-    ], 
-    "defaults": {}, 
-    "docstring": "Return all users.", 
-    "endpoint": "get_users", 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 73
-    }, 
-    "methods": [
-      "GET", 
-      "HEAD", 
-      "OPTIONS"
-    ], 
-    "rule": "/users"
-  }, 
-  {
-    "args": [
-      "None"
-    ], 
-    "defaults": {}, 
-    "docstring": "Creates a new user.", 
-    "endpoint": "post_user", 
-    "form_data": [
-      "username"
-    ], 
-    "location": {
-      "filename": "%PATH%/examples/custom/blog.py", 
-      "line": 88
-    }, 
-    "methods": [
-      "OPTIONS", 
-      "POST"
-    ], 
-    "rule": "/users"
-  }
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Return all posts.",
+        "endpoint": "get_posts",
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 47
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Admin interface.",
+        "endpoint": "admin",
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 96
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/admin"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Create a new post.",
+        "endpoint": "post_post",
+        "form_data": [
+            "title",
+            "content",
+            "authorid"
+        ],
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 62
+        },
+        "methods": [
+            "OPTIONS",
+            "POST"
+        ],
+        "rule": "/post"
+    },
+    {
+        "args": [
+            "id"
+        ],
+        "defaults": {},
+        "docstring": "Return the post for the given id.",
+        "endpoint": "get_post",
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 54
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/post/<int:id>"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Return all posts.",
+        "endpoint": "get_posts",
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 47
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/posts"
+    },
+    {
+        "args": [
+            "id"
+        ],
+        "defaults": {},
+        "docstring": "Return the user for the given id.",
+        "endpoint": "get_user",
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 80
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/user/<int:id>"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Return all users.",
+        "endpoint": "get_users",
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 73
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/users"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Creates a new user.",
+        "endpoint": "post_user",
+        "form_data": [
+            "username"
+        ],
+        "location": {
+            "filename": "%PATH%/examples/custom/blog.py",
+            "line": 88
+        },
+        "methods": [
+            "OPTIONS",
+            "POST"
+        ],
+        "rule": "/users"
+    }
 ]

--- a/tests/files/simple.json
+++ b/tests/files/simple.json
@@ -1,1 +1,185 @@
-[{"args":["None"],"defaults":{},"docstring":"Return all posts.","endpoint":"get_posts","location":{"filename":"%PATH%/examples/simple/blog.py","line":45},"methods":["GET","HEAD","OPTIONS"],"rule":"/"},{"args":["None"],"defaults":{},"docstring":"Admin interface.","endpoint":"admin","location":{"filename":"%PATH%/examples/simple/blog.py","line":113},"methods":["GET","HEAD","OPTIONS"],"rule":"/admin"},{"args":["greeting","id"],"defaults":{"greeting":"Hello"},"docstring":"Return the user for the given id.","endpoint":"greet_user","location":{"filename":"%PATH%/examples/simple/blog.py","line":96},"methods":["GET","HEAD","OPTIONS"],"rule":"/greet/<greeting>/user/<int:id>"},{"args":["id"],"defaults":{"id":-1},"docstring":"Return the user for the given id.","endpoint":"hello_to_user","location":{"filename":"%PATH%/examples/simple/blog.py","line":86},"methods":["GET","HEAD","OPTIONS"],"rule":"/hello/user/<int:id>"},{"args":["None"],"defaults":{},"docstring":"Create a new post.\n    Form Data: title, content, authorid.\n    ","endpoint":"post_post","location":{"filename":"%PATH%/examples/simple/blog.py","line":59},"methods":["OPTIONS","POST"],"rule":"/post"},{"args":["id"],"defaults":{},"docstring":"Return the post for the given id.","endpoint":"get_post","location":{"filename":"%PATH%/examples/simple/blog.py","line":52},"methods":["GET","HEAD","OPTIONS"],"rule":"/post/<int:id>"},{"args":["None"],"defaults":{},"docstring":"Return all posts.","endpoint":"get_posts","location":{"filename":"%PATH%/examples/simple/blog.py","line":45},"methods":["GET","HEAD","OPTIONS"],"rule":"/posts"},{"args":["id"],"defaults":{},"docstring":"Return the user for the given id.","endpoint":"get_user","location":{"filename":"%PATH%/examples/simple/blog.py","line":79},"methods":["GET","HEAD","OPTIONS"],"rule":"/user/<int:id>"},{"args":["None"],"defaults":{},"docstring":"Return all users.","endpoint":"get_users","location":{"filename":"%PATH%/examples/simple/blog.py","line":72},"methods":["GET","HEAD","OPTIONS"],"rule":"/users"},{"args":["None"],"defaults":{},"docstring":"Creates a new user.\n    Form Data: username.\n    ","endpoint":"post_user","location":{"filename":"%PATH%/examples/simple/blog.py","line":103},"methods":["OPTIONS","POST"],"rule":"/users"}]
+[
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Return all posts.",
+        "endpoint": "get_posts",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 46
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Admin interface.",
+        "endpoint": "admin",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 114
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/admin"
+    },
+    {
+        "args": [
+            "greeting",
+            "id"
+        ],
+        "defaults": {
+            "greeting": "Hello"
+        },
+        "docstring": "Return the user for the given id.",
+        "endpoint": "greet_user",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 97
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/greet/<greeting>/user/<int:id>"
+    },
+    {
+        "args": [
+            "id"
+        ],
+        "defaults": {
+            "id": -1
+        },
+        "docstring": "Return the user for the given id.",
+        "endpoint": "hello_to_user",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 87
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/hello/user/<int:id>"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Create a new post.\n    Form Data: title, content, authorid.\n",
+        "endpoint": "post_post",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 60
+        },
+        "methods": [
+            "OPTIONS",
+            "POST"
+        ],
+        "rule": "/post"
+    },
+    {
+        "args": [
+            "id"
+        ],
+        "defaults": {},
+        "docstring": "Return the post for the given id.",
+        "endpoint": "get_post",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 53
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/post/<int:id>"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Return all posts.",
+        "endpoint": "get_posts",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 46
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/posts"
+    },
+    {
+        "args": [
+            "id"
+        ],
+        "defaults": {},
+        "docstring": "Return the user for the given id.",
+        "endpoint": "get_user",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 80
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/user/<int:id>"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Return all users.",
+        "endpoint": "get_users",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 73
+        },
+        "methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
+        ],
+        "rule": "/users"
+    },
+    {
+        "args": [
+            "None"
+        ],
+        "defaults": {},
+        "docstring": "Creates a new user.\n    Form Data: username.\n",
+        "endpoint": "post_user",
+        "location": {
+            "filename": "%PATH%/examples/simple/blog.py",
+            "line": 104
+        },
+        "methods": [
+            "OPTIONS",
+            "POST"
+        ],
+        "rule": "/users"
+    }
+]

--- a/tests/files/simple_private.html
+++ b/tests/files/simple_private.html
@@ -176,7 +176,7 @@
             </ul>
             <p class="docstring">Create a new post.<br>
     Form Data: title, content, authorid.<br>
-    </p>
+</p>
         </div>
         
         <div class="mapping">
@@ -304,7 +304,7 @@
             </ul>
             <p class="docstring">Creates a new user.<br>
     Form Data: username.<br>
-    </p>
+</p>
         </div>
         
     </body>

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -7,8 +7,6 @@ import os
 from flask import Flask
 from flask_selfdoc import Autodoc, Selfdoc
 
-from tests.config import NEW_FN_OFFSETS
-
 
 class TestAutodoc(unittest.TestCase):
 
@@ -261,8 +259,8 @@ class TestAutodoc(unittest.TestCase):
             self.assertIn('Returns arguments', doc)
 
     def testLocation(self):
-        offset = 4 if NEW_FN_OFFSETS else 3
-        line_no = inspect.stack()[0][2] + offset  # the doc() line
+        offset_to_def = 4
+        line_no = inspect.stack()[0].lineno + offset_to_def
 
         @self.app.route('/location')
         @self.autodoc.doc()
@@ -277,8 +275,8 @@ class TestAutodoc(unittest.TestCase):
             self.assertIn(self.thisFile(), d['location']['filename'])
 
     def testLocationWithExtraDecorators(self):
-        offset = 13 if NEW_FN_OFFSETS else 12
-        line_no = inspect.stack()[0][2] + offset  # the doc() line
+        offset_to_def = 13
+        line_no = inspect.stack()[0].lineno + offset_to_def
 
         def pointless_decorator():
             def fn(f):

--- a/tests/test_check_example.py
+++ b/tests/test_check_example.py
@@ -6,17 +6,20 @@ from examples.custom.blog import app as custom_app
 from examples.simple.blog import app as simple_app
 
 from tests.config import IS_WINDOWS
-from tests.config import NEW_FN_OFFSETS
 
 # To regenerate the baseline data files, change this to True.
 REGENERATE_FILES = False
 
 
-class TestApp(object):
+class TestApp(unittest.TestCase):
     maxDiff = None
+    path = None
+    filename = None
+    app = None
 
     def setUp(self):
-        self.client = self.app.test_client()
+        if self.__class__ != TestApp:
+            self.client = self.app.test_client()
 
     def get_request(self):
         r = self.client.get(self.path)
@@ -26,21 +29,23 @@ class TestApp(object):
 
     def sub_pwd(self, data):
         file_path = os.getcwd()
-        return data.replace(file_path, "%PATH%")        
+        return data.replace(file_path, "%PATH%")
 
     @unittest.skipIf(REGENERATE_FILES, "Regenerating the baseline files")
-    @unittest.skipIf(not NEW_FN_OFFSETS, "This test will not work with the old way of detecting fn line numbers")
     @unittest.skipIf(IS_WINDOWS, "This test will not work with Windows style filepaths")
     def test_output(self):
+        if self.__class__ == TestApp:
+            self.skipTest('base test class')
         data = self.get_request()
+        data = self.sub_pwd(data)
         with open(self.filename) as f:
             expected = f.read()
-
-        data = self.sub_pwd(data)
         self.assertEqual(data, expected)
 
     @unittest.skipIf(not REGENERATE_FILES, "This is only run to regenerate the baseline.")
     def test_regenerate(self):
+        if self.__class__ == TestApp:
+            self.skipTest('base test class')
         data = self.get_request()
         data = self.sub_pwd(data)
         with open(self.filename, "w") as f:
@@ -48,31 +53,31 @@ class TestApp(object):
         self.assertTrue(False, "This test always fails, change REGENERATE_FILES back to False to proceed.")
 
 
-class TestSimpleApp(TestApp, unittest.TestCase):
+class TestSimpleApp(TestApp):
     app = simple_app
     filename = "tests/files/simple.html"
     path = "/doc"
 
 
-class TestSimpleAppJSONOutput(TestApp, unittest.TestCase):
+class TestSimpleAppJSONOutput(TestApp):
     app = simple_app
     filename = "tests/files/simple.json"
     path = "/doc/json"
 
 
-class TestSimpleAppBuiltinJSONOutput(TestApp, unittest.TestCase):
+class TestSimpleAppBuiltinJSONOutput(TestApp):
     app = simple_app
     filename = "tests/files/builtin.json"
     path = "/doc/builtin_json"
 
 
-class TestSimpleAppPrivateGroup(TestApp, unittest.TestCase):
+class TestSimpleAppPrivateGroup(TestApp):
     app = simple_app
     filename = "tests/files/simple_private.html"
     path = "/doc/private"
 
 
-class TestFactoryApp(TestApp, unittest.TestCase):
+class TestFactoryApp(TestApp):
     filename = "tests/files/factory.html"
     path = "/doc/"
 
@@ -83,13 +88,13 @@ class TestFactoryApp(TestApp, unittest.TestCase):
         cls.app = factory_create_app()
 
 
-class TestCustomApp(TestApp, unittest.TestCase):
+class TestCustomApp(TestApp):
     app = custom_app
     filename = "tests/files/custom.html"
     path = "/doc/"
 
 
-class TestCustomAppJSONOutput(TestApp, unittest.TestCase):
+class TestCustomAppJSONOutput(TestApp):
     app = custom_app
     filename = "tests/files/custom.json"
     path = "/doc/json"


### PR DESCRIPTION
## Issue 1
### Cause
When installing `Flask` 2.0 with python > 3.6, the chosen version of its `Jinja2` dependency is >= `3.1.0`:

```
$ docker run -it --rm python:3.7 bash
root@44ff1cecc27d:/# pip3 install Flask==2.0
Collecting Flask==2.0
  Downloading Flask-2.0.0-py3-none-any.whl (93 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 93.2/93.2 KB 2.5 MB/s eta 0:00:00
Collecting Jinja2>=3.0
  Downloading Jinja2-3.1.2-py3-none-any.whl (133 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.1/133.1 KB 7.5 MB/s eta 0:00:00
```

With python 3.6, the installed `Jinja2 ` dependency seems to be < `3.1.0 ` which should not be problematic as I'll explain next.
```
$ docker run -it --rm python:3.6 bash
root@7a7dccf967f2:/# pip3 install Flask==2.0
Collecting Flask==2.0
  Downloading Flask-2.0.0-py3-none-any.whl (93 kB)
     |████████████████████████████████| 93 kB 1.6 MB/s 
Collecting Jinja2>=3.0
  Downloading Jinja2-3.0.3-py3-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 6.4 MB/s 
```

### Consequences
`import flask_selfdoc` will then raise an `ImportError` because it tries to import the follow function and class that were deprecated in `Jinja2` 3.0 and removed in `Jinja2` 3.1:
- [jinja2.evalcontextfilter](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.evalcontextfilter) -> moved to `jinja2.pass_eval_context`
- [jinja2.Markup](https://tedboy.github.io/jinja2/generated/generated/jinja2.Markup.html) -> moved to `jinja2.utils.markupsafe.Markup`

## Issue 2
### Cause
The way that the line number of a decorator is detected changed across python versions:
- python <= 3.8: `stack()[1].lineno` points to the line above the decorated function (= to the closest decorator, not necessarily the one that did the call to `stack()`)
- python 3.9 and 3.10:  `stack()[1].lineno` points to the line of the decorated function
- python 3.11:  `stack()[1].lineno` points to the exact line of the decorator that did the call to `stack()`

#### Example:

```
    1   |def call_stack_and_get_lineno():
    2   |
    3   |    def decorator(func):
    4   |        calling_frame = stack()[1]
    5   |        print(calling_frame.lineno)
    6   |        return func
    7   |
    8   |    return decorator
    9   |
    10  |
    11  |@decorator1
    12  |@call_stack_and_get_lineno
    13  |@decorator2
    14  |def func():
    15  |    pass
```

- python <= 3.8: will print line 13
- python 3.9 and 3.10: will print line 14 (desired behaviour)
- python 3.11: will print line 12

### Consequences
- unit tests don't pass for python 3.11
- unit tests pass for python <= 3.8 but only because we adjust them (add a `-1` offset to the detected line number)


## What this PR does
### Issue 1
- Avoid `Jinja2`-related `ImportError` by trying the old and the new import for each Jinja function/class that is now deprecated
- Remove the check `Flask < 2.0` from the package dependencies
- Adapt the ranges of tested python and `Flask` versions in the unit tests (WIP)
  - `minimal-test.yml`: remove python 3.7 (security support ends in 4 months), add python 3.10
  - `test.yml`: add `Flask` 2.1 (not compatible with python 3.6), add python 3.10 and 3.11 (not compatible with `Flask` 1.0)
 - Adapt the import of the Flask app context to version 2.3 where  `_app_ctx_stack` is removed
 - Install target Flask version for tests using `pip3` (easier than with `poetry`) and manually override its dependency versions when they're too recent (`itsdangerous`, `Jinja2` and `MarkupSafe` for Flask 1.X)
 - List all installed packages before running tests
### Issue 2
- Fix line number detection by reading the source file and finding the next line starting with `def `